### PR TITLE
Mitigate-false-repair-errors

### DIFF
--- a/custom_components/portainer/coordinator.py
+++ b/custom_components/portainer/coordinator.py
@@ -90,11 +90,7 @@ class PortainerCoordinator(DataUpdateCoordinator):
         self.datasets_hass_device_id = None
 
         # Track consecutive failures for repair issues (only create after 3 failures)
-        self._consecutive_failures = {
-            "containers": {},
-            "endpoints": {},
-            "stacks": {}
-        }
+        self._consecutive_failures = {"containers": {}, "endpoints": {}, "stacks": {}}
 
         self.selected_endpoints = set(
             str(e)
@@ -223,7 +219,7 @@ class PortainerCoordinator(DataUpdateCoordinator):
             model_key_map = {
                 "Container": "containers",
                 "Endpoint": "endpoints",
-                "Stack": "stacks"
+                "Stack": "stacks",
             }
             failure_key = model_key_map.get(device.model, device.model.lower() + "s")
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -692,20 +692,20 @@ class TestPortainerCoordinator:
         all_devices = [mock_device_container]
 
         # Test scenario: container not found for 3 consecutive updates
-        with patch("custom_components.portainer.coordinator.dr") as mock_dr, \
-                patch("custom_components.portainer.coordinator.async_create_issue") as mock_create_issue, \
-                patch("custom_components.portainer.coordinator.async_delete_issue") as mock_delete_issue:
+        with patch("custom_components.portainer.coordinator.dr") as mock_dr, patch(
+            "custom_components.portainer.coordinator.async_create_issue"
+        ) as mock_create_issue, patch(
+            "custom_components.portainer.coordinator.async_delete_issue"
+        ) as mock_delete_issue:
 
             mock_device_registry = Mock()
             mock_dr.async_get.return_value = mock_device_registry
-            mock_device_registry.async_entries_for_config_entry.return_value = all_devices
+            mock_device_registry.async_entries_for_config_entry.return_value = (
+                all_devices
+            )
 
             # First update: container not found (failure 1)
-            coordinator.raw_data = {
-                "containers": {},
-                "endpoints": {},
-                "stacks": {}
-            }
+            coordinator.raw_data = {"containers": {}, "endpoints": {}, "stacks": {}}
             await coordinator._async_update_data()
 
             # Should not create issue after 1 failure
@@ -723,7 +723,9 @@ class TestPortainerCoordinator:
             # Should create issue after 3 failures
             mock_create_issue.assert_called_once()
             call_args = mock_create_issue.call_args
-            assert "missing_container_test_entry_id_1_test-container" in call_args[1]  # issue_key
+            assert (
+                "missing_container_test_entry_id_1_test-container" in call_args[1]
+            )  # issue_key
 
     @pytest.mark.asyncio
     async def test_failure_count_cleared_when_device_found(self, coordinator):
@@ -737,13 +739,17 @@ class TestPortainerCoordinator:
 
         all_devices = [mock_device]
 
-        with patch("custom_components.portainer.coordinator.dr") as mock_dr, \
-                patch("custom_components.portainer.coordinator.async_create_issue") as mock_create_issue, \
-                patch("custom_components.portainer.coordinator.async_delete_issue") as mock_delete_issue:
+        with patch("custom_components.portainer.coordinator.dr") as mock_dr, patch(
+            "custom_components.portainer.coordinator.async_create_issue"
+        ) as mock_create_issue, patch(
+            "custom_components.portainer.coordinator.async_delete_issue"
+        ) as mock_delete_issue:
 
             mock_device_registry = Mock()
             mock_dr.async_get.return_value = mock_device_registry
-            mock_device_registry.async_entries_for_config_entry.return_value = all_devices
+            mock_device_registry.async_entries_for_config_entry.return_value = (
+                all_devices
+            )
 
             # Simulate 2 failures first
             coordinator.raw_data = {"containers": {}, "endpoints": {}, "stacks": {}}
@@ -755,19 +761,26 @@ class TestPortainerCoordinator:
 
             # Now device is found - should clear failure count
             coordinator.raw_data = {
-                "containers": {"1_test-container": {"Name": "test-container", "EndpointId": "1"}},
+                "containers": {
+                    "1_test-container": {"Name": "test-container", "EndpointId": "1"}
+                },
                 "endpoints": {},
-                "stacks": {}
+                "stacks": {},
             }
             await coordinator._async_update_data()
 
             # Should delete any existing issues and clear counter
             mock_delete_issue.assert_called_once()
             call_args = mock_delete_issue.call_args
-            assert "missing_container_test_entry_id_1_test-container" in call_args[1]  # issue_key
+            assert (
+                "missing_container_test_entry_id_1_test-container" in call_args[1]
+            )  # issue_key
 
             # Counter should be cleared
-            assert "missing_container_test_entry_id_1_test-container" not in coordinator._consecutive_failures["containers"]
+            assert (
+                "missing_container_test_entry_id_1_test-container"
+                not in coordinator._consecutive_failures["containers"]
+            )
 
     def test_get_containers_with_none_container_handling(self, coordinator, mock_api):
         """Test get containers with None container handling."""

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -679,6 +679,96 @@ class TestPortainerCoordinator:
         assert coordinator._systemstats_errored == []
         assert coordinator.datasets_hass_device_id is None
 
+    @pytest.mark.asyncio
+    async def test_consecutive_failure_tracking_for_repair_issues(self, coordinator):
+        """Test that repair issues are only created after 3 consecutive failures."""
+        # Set up test devices
+        mock_device_container = Mock()
+        mock_device_container.identifiers = {(DOMAIN, "test_entry_id_1_test-container")}
+        mock_device_container.model = "Container"
+        mock_device_container.name = "test-container"
+        mock_device_container.id = "device_123"
+
+        all_devices = [mock_device_container]
+
+        # Test scenario: container not found for 3 consecutive updates
+        with patch("custom_components.portainer.coordinator.dr") as mock_dr, \
+                patch("custom_components.portainer.coordinator.async_create_issue") as mock_create_issue, \
+                patch("custom_components.portainer.coordinator.async_delete_issue") as mock_delete_issue:
+
+            mock_device_registry = Mock()
+            mock_dr.async_get.return_value = mock_device_registry
+            mock_device_registry.async_entries_for_config_entry.return_value = all_devices
+
+            # First update: container not found (failure 1)
+            coordinator.raw_data = {
+                "containers": {},
+                "endpoints": {},
+                "stacks": {}
+            }
+            await coordinator._async_update_data()
+
+            # Should not create issue after 1 failure
+            mock_create_issue.assert_not_called()
+
+            # Second update: container still not found (failure 2)
+            await coordinator._async_update_data()
+
+            # Should not create issue after 2 failures
+            mock_create_issue.assert_not_called()
+
+            # Third update: container still not found (failure 3)
+            await coordinator._async_update_data()
+
+            # Should create issue after 3 failures
+            mock_create_issue.assert_called_once()
+            call_args = mock_create_issue.call_args
+            assert "missing_container_test_entry_id_1_test-container" in call_args[1]  # issue_key
+
+    @pytest.mark.asyncio
+    async def test_failure_count_cleared_when_device_found(self, coordinator):
+        """Test that failure count is cleared when device is found again."""
+        # Set up test device
+        mock_device = Mock()
+        mock_device.identifiers = {(DOMAIN, "test_entry_id_1_test-container")}
+        mock_device.model = "Container"
+        mock_device.name = "test-container"
+        mock_device.id = "device_123"
+
+        all_devices = [mock_device]
+
+        with patch("custom_components.portainer.coordinator.dr") as mock_dr, \
+                patch("custom_components.portainer.coordinator.async_create_issue") as mock_create_issue, \
+                patch("custom_components.portainer.coordinator.async_delete_issue") as mock_delete_issue:
+
+            mock_device_registry = Mock()
+            mock_dr.async_get.return_value = mock_device_registry
+            mock_device_registry.async_entries_for_config_entry.return_value = all_devices
+
+            # Simulate 2 failures first
+            coordinator.raw_data = {"containers": {}, "endpoints": {}, "stacks": {}}
+            await coordinator._async_update_data()  # failure 1
+            await coordinator._async_update_data()  # failure 2
+
+            # Verify issue not created yet
+            mock_create_issue.assert_not_called()
+
+            # Now device is found - should clear failure count
+            coordinator.raw_data = {
+                "containers": {"1_test-container": {"Name": "test-container", "EndpointId": "1"}},
+                "endpoints": {},
+                "stacks": {}
+            }
+            await coordinator._async_update_data()
+
+            # Should delete any existing issues and clear counter
+            mock_delete_issue.assert_called_once()
+            call_args = mock_delete_issue.call_args
+            assert "missing_container_test_entry_id_1_test-container" in call_args[1]  # issue_key
+
+            # Counter should be cleared
+            assert "missing_container_test_entry_id_1_test-container" not in coordinator._consecutive_failures["containers"]
+
     def test_get_containers_with_none_container_handling(self, coordinator, mock_api):
         """Test get containers with None container handling."""
         # Set up endpoints first


### PR DESCRIPTION
## Proposed change
fix false repair errors by introducing an error counter for status-updates.
only when 3 updates in a row failed, repairs gets created.
This avoids repair-issues when the api is non-responsive only for a few seconds during high load

## Type of change

- [ fix false repair errors ] Bugfix

## Additional information

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
